### PR TITLE
Move sqs-receiver main script file into src folder (fix sonar coverage)

### DIFF
--- a/packages/sqs-receiver-service/__tests__/sqs-receiver-service.spec.js
+++ b/packages/sqs-receiver-service/__tests__/sqs-receiver-service.spec.js
@@ -1,4 +1,4 @@
-import '../index.js'
+import '..'
 jest.mock('../src/receiver.js', () => {
   return jest.fn(async () => {
     global.receiverInitialised = true

--- a/packages/sqs-receiver-service/ecosystem.config.yml
+++ b/packages/sqs-receiver-service/ecosystem.config.yml
@@ -1,5 +1,5 @@
 apps:
-  - script: ./index.js
+  - script: ./src/sqs-receiver-service.js
     name: 'Sales Queue'
     env:
       RECEIVER_PREFIX: SALES_QUEUE
@@ -9,7 +9,7 @@ apps:
     interpreter: 'node@13.9.0'
     autorestart: false
 
-  - script: ./index.js
+  - script: ./src/sqs-receiver-service.js
     name: 'Sales dead letter queue'
     env:
       RECEIVER_PREFIX: SALES_DEAD_LETTER_QUEUE

--- a/packages/sqs-receiver-service/package.json
+++ b/packages/sqs-receiver-service/package.json
@@ -2,16 +2,28 @@
   "name": "sqs-receiver-service",
   "version": "1.0.0",
   "description": "SQS Receiver service",
-  "main": "index.js",
-  "type": "module",
   "private": true,
-  "license": "SEE LICENSE IN LICENSE",
+  "type": "module",
   "engines": {
     "node": ">=13"
   },
+  "author": "DEFRA",
+  "license": "SEE LICENSE IN LICENSE",
+  "main": "src/sqs-receiver-service.js",
+  "directories": {
+    "lib": "src",
+    "test": "__tests__"
+  },
+  "files": [
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@ssh.github.com:443/DEFRA/rod-licencing"
+  },
   "scripts": {
-    "run": "pm2 start ecosystem.config.yml",
-    "test": "jest"
+    "start": "pm2 start ecosystem.config.yml",
+    "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
     "@hapi/joi": "^17.1.0",
@@ -20,6 +32,5 @@
     "node-fetch": "^2.6.0",
     "pm2": "^4.2.3",
     "uuid": "^7.0.1"
-  },
-  "author": ""
+  }
 }

--- a/packages/sqs-receiver-service/src/sqs-receiver-service.js
+++ b/packages/sqs-receiver-service/src/sqs-receiver-service.js
@@ -2,7 +2,7 @@
 /**
  * Initializes and starts the receiver loop
  */
-import receiver from './src/receiver.js'
+import receiver from './receiver.js'
 
 /**
  * Start the receiver


### PR DESCRIPTION
Move sqs-receiver main script file into src folder (to fix sonar coverage and ensure all source files are kept inside the src directory)